### PR TITLE
ignore Mac OS .DS_Store files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.1.2 / 2016-07-24
+------------------
+- ignore Mac OS .DS_Store files
+
+
 0.1.1 / 2016-05-12
 ------------------
 - make shell command

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ Usage
 
 **Pause or turn off Dropbox on the machine you run this on.**
 
+
+
+###Run on project source directory with package.json and node_modules.
+
+Options:
+`--overwrite` Overwrite existing symlinks.
+
+###Example command
 ```
-
-  fix-dropbox-node_modules-symlinks@0.1.0
-
-    Run on project source directory with package.json and node_modules.
-
-    options:
-
-      --overwrite Overwrite existing symlinks.
-
+fix-dropbox-node_modules-symlinks --overwrite
 ```
 
 

--- a/cli.js
+++ b/cli.js
@@ -31,6 +31,7 @@ function main () {
   console.log('')
   fs.readdirSync(nodeModulesDir).forEach(mod => {
     if (mod === '.bin') return
+    if (mod === '.DS_Store') return; // ignore Mac OS folder attributes file (such as icon position)
     let pkgJson = JSON.parse(fs.readFileSync(path.join('node_modules', mod, 'package.json'), 'utf8'))
     if (!pkgJson.bin) return
 


### PR DESCRIPTION
I added one line to ignore .DS_Store files. I copied cli.js into a project with symlink problems and typed node cli.js --overwrite and it worked, ignoring the .DS_Store file, so I think the fix works.
